### PR TITLE
fix(script.js): Use updated link content to copy to clipboard

### DIFF
--- a/action/script.js
+++ b/action/script.js
@@ -41,7 +41,7 @@
     text.innerHTML = link;
 
     image.addEventListener("click", e => {
-      copyAction(link);
+      copyAction(text.textContent);
     });
 
     closeBtn.addEventListener("click", e => {


### PR DESCRIPTION
Fix a bug that keeps coping the original link without updates